### PR TITLE
Fix docker build command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ git clone git@github.com:Miljar/exiftool-docker.git && cd exiftool-docker
 ## Build container
 
 ```shell
-$ docker built -t exiftool .
+$ docker build -t exiftool .
 ```
 
 ## Run container


### PR DESCRIPTION
Copy & paste from the readme doesn't work. This change fixes this.